### PR TITLE
zizmor audit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -108,6 +109,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install toolchain # Can't switch to "dtolnay/rust-toolchain", it will cause "Build UI setup file" error.
         uses: actions-rs/toolchain@v1
@@ -262,6 +264,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4 # Just for getting Dockerfile, not need download submodules
+        with:
+          persist-credentials: false
         
       - name: Download binaries
         uses: actions/download-artifact@v4
@@ -433,6 +437,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4 # Just for getting Dockerfile, not need download submodules
+        with:
+          persist-credentials: false
         
       - name: Download binaries
         uses: actions/download-artifact@v4
@@ -601,6 +607,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,11 +23,8 @@ env:
   GHCR_IMAGE_CLASSIC_NAME: ghcr.io/${{ github.repository }}
 
 permissions:
-  contents: write
-  packages: write
-  id-token: write
-  attestations: write
-  
+  contents: read
+
 jobs:
 
   # binary build
@@ -44,7 +41,9 @@ jobs:
           - { name: "armv7",   target: "armv7-unknown-linux-musleabihf", os: "ubuntu-24.04",     cross-build: true } # No cross build toolkit for armv8 -> armv7
           - { name: "i386",    target: "i686-unknown-linux-musl",        os: "ubuntu-24.04",     cross-build: true }
           #- { name: "amd64fb", target: "x86_64-unknown-freebsd",         os: "ubuntu-24.04",     cross-build: true }
-
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       
       - name: Checkout
@@ -102,6 +101,9 @@ jobs:
   build-win:
     name: Build - windows
     runs-on: windows-2022
+    permissions:
+      id-token: write
+      attestations: write
 
     steps:
       
@@ -223,7 +225,9 @@ jobs:
           - { os: "linux", name: "i386", suffix: "" }
           #- { os: "linux", name: "amd64fb", suffix: "" }
           - { os: "windows", name: "x86_64", suffix: "-unsigned" }
-          
+    permissions:
+      contents: write
+     
     steps:
 
       - name: Download binaries (${{ matrix.job.os }} - ${{ matrix.job.name }})
@@ -259,6 +263,8 @@ jobs:
           - { name: "arm64v8", docker_platform: "linux/arm64",  s6_platform: "aarch64", os: "ubuntu-24.04-arm" }
           - { name: "armv7",   docker_platform: "linux/arm/v7", s6_platform: "armhf",   os: "ubuntu-24.04-arm" }
           - { name: "i386",    docker_platform: "linux/386",    s6_platform: "i686",    os: "ubuntu-24.04" }
+    permissions:
+      packages: write
 
     steps:
 
@@ -328,6 +334,9 @@ jobs:
     name: Docker manifest (s6)
     needs: docker
     runs-on: ubuntu-24.04-arm
+    permissions:
+      packages: write
+      id-token: write
 
     steps:
 
@@ -432,6 +441,8 @@ jobs:
           - { name: "arm64v8", docker_platform: "linux/arm64",  os: "ubuntu-24.04-arm" }
           - { name: "armv7",   docker_platform: "linux/arm/v7", os: "ubuntu-24.04-arm" }
           - { name: "i386",    docker_platform: "linux/386",    os: "ubuntu-24.04" }
+    permissions:
+      packages: write
 
     steps:
 
@@ -499,6 +510,9 @@ jobs:
     name: Docker manifest (Classic)
     needs: docker
     runs-on: ubuntu-24.04-arm
+    permissions:
+      packages: write
+      id-token: write
 
     steps:
 
@@ -602,6 +616,9 @@ jobs:
           - { name: "arm64v8", debian_platform: "arm64",   crossbuild_package: "",                           os: "ubuntu-24.04-arm" }
           - { name: "armv7",   debian_platform: "armhf",   crossbuild_package: "crossbuild-essential-armhf", os: "ubuntu-24.04-arm" }
           - { name: "i386",    debian_platform: "i386",    crossbuild_package: "crossbuild-essential-i386",  os: "ubuntu-24.04" }
+    permissions:
+      id-token: write
+      attestations: write
 
     steps:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -422,10 +422,13 @@ jobs:
  
       - name: Sign the images with GitHub OIDC Token
         if: github.event_name != 'workflow_dispatch'
+        env:
+          DOCKER_DIGEST: ${{ steps.manifest-latest-docker.outputs.images }}
+          GHCR_DIGEST: ${{ steps.manifest-latest-ghcr.outputs.images }}
         run: |
           # --recursive for multiarch tags will sign all the images that it referenced
-          cosign sign --yes --recursive ${{ steps.manifest-latest-docker.outputs.images }}
-          cosign sign --yes --recursive ${{ steps.manifest-latest-ghcr.outputs.images }}
+          cosign sign --yes --recursive ${DOCKER_DIGEST}
+          cosign sign --yes --recursive ${GHCR_DIGEST}
 
   # docker build and push of single-arch images
   docker-classic:
@@ -598,10 +601,13 @@ jobs:
 
       - name: Sign the images with GitHub OIDC Token
         if: github.event_name != 'workflow_dispatch'
+        env:
+          DOCKER_DIGEST: ${{ steps.manifest-latest-docker.outputs.images }}
+          GHCR_DIGEST: ${{ steps.manifest-latest-ghcr.outputs.images }}
         run: |
           # --recursive for multiarch tags will sign all the images that it referenced
-          cosign sign --yes --recursive ${{ steps.manifest-latest-docker.outputs.images }}
-          cosign sign --yes --recursive ${{ steps.manifest-latest-ghcr.outputs.images }}
+          cosign sign --yes --recursive ${DOCKER_DIGEST}
+          cosign sign --yes --recursive ${GHCR_DIGEST}
 
   deb-package:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -617,6 +617,7 @@ jobs:
           - { name: "armv7",   debian_platform: "armhf",   crossbuild_package: "crossbuild-essential-armhf", os: "ubuntu-24.04-arm" }
           - { name: "i386",    debian_platform: "i386",    crossbuild_package: "crossbuild-essential-i386",  os: "ubuntu-24.04" }
     permissions:
+      contents: write
       id-token: write
       attestations: write
 


### PR DESCRIPTION
Reported by [zizmor](https://github.com/woodruffw/zizmor)

* All checkouts are added `persist-credentials: false` option, because no any jobs needs `git push` or something: [ref](https://woodruffw.github.io/zizmor/audits/#artipacked)
* Better permission control for jobs: [ref](https://woodruffw.github.io/zizmor/audits/#excessive-permissions)
* ***Ignored*** any cache related errors: [ref](https://woodruffw.github.io/zizmor/audits/#cache-poisoning)